### PR TITLE
Delete attribution string from options to always use the ones provide…

### DIFF
--- a/v-leaflet-esri/src/main/java/org/vaadin/addon/leaflet/esri/client/EsriLeafletBasemapConnector.java
+++ b/v-leaflet-esri/src/main/java/org/vaadin/addon/leaflet/esri/client/EsriLeafletBasemapConnector.java
@@ -20,6 +20,7 @@ public class EsriLeafletBasemapConnector extends LeafletTileLayerConnector {
     protected BasemapLayerOptions createOptions() {
         BasemapLayerOptions o = super.createOptions().cast();
         EsriLeafletBasemapLayerState s = getState();
+        deleteAttributionToUseDefaultProvidedByEsri(o);
         if (s.token != null) {
             o.setToken(s.token);
         }
@@ -30,4 +31,9 @@ public class EsriLeafletBasemapConnector extends LeafletTileLayerConnector {
     protected BasemapLayer createTileLayer(TileLayerOptions o) {
         return BasemapLayer.create(getState().layerType, (BasemapLayerOptions) o);
     }
+
+    private static native void deleteAttributionToUseDefaultProvidedByEsri(BasemapLayerOptions o) 
+    /*-{
+        delete o.attribution;
+    }-*/;
 }


### PR DESCRIPTION
…d by Esri